### PR TITLE
Add superuser-only app version page

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -47,7 +47,11 @@ jobs:
           IMAGE_ID: "ghcr.io/${{ github.repository }}/${{ inputs.image-name }}"
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          docker build -t ${IMAGE_ID}:${VERSION} .
+          docker build \
+            --build-arg BUILD_VERSION=${VERSION} \
+            --build-arg BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+            --build-arg BUILD_COMMIT=${GITHUB_SHA} \
+            -t ${IMAGE_ID}:${VERSION} .
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           docker push ${IMAGE_ID}:${VERSION}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,12 @@ RUN python /app/manage.py collectstatic --noinput
 
 # Runtime image
 FROM base
+ARG BUILD_VERSION=dev
+ARG BUILD_DATE=N/A
+ARG BUILD_COMMIT=N/A
+ENV BUILD_VERSION=${BUILD_VERSION}
+ENV BUILD_DATE=${BUILD_DATE}
+ENV BUILD_COMMIT=${BUILD_COMMIT}
 ENV SQLITE_DATABASE_PATH=/data/db.sqlite3
 COPY --from=staticfiles /app /app
 COPY entrypoint.sh /entrypoint.sh

--- a/bookmarks/bookmarks/tests/test_views.py
+++ b/bookmarks/bookmarks/tests/test_views.py
@@ -334,6 +334,87 @@ class AuthViewTests(TestCase):
         self.assertEqual(response.status_code, 302)
 
 
+class AppVersionViewTests(TestCase):
+    def setUp(self):
+        self.superuser = User.objects.create_superuser(
+            'superuser', 'super@example.com', 'password'
+        )
+        self.staff_user = User.objects.create_user(
+            'staffuser', 'staff@example.com', 'password', is_staff=True
+        )
+        self.regular_user = User.objects.create_user(
+            'regularuser', 'regular@example.com', 'password'
+        )
+
+    def test_anonymous_redirects_to_login(self):
+        response = self.client.get(reverse('app_version'))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('/login/', response['Location'])
+
+    def test_superuser_returns_200(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get(reverse('app_version'))
+        self.assertEqual(response.status_code, 200)
+
+    def test_regular_user_returns_403(self):
+        self.client.force_login(self.regular_user)
+        response = self.client.get(reverse('app_version'))
+        self.assertEqual(response.status_code, 403)
+
+    def test_staff_non_superuser_returns_403(self):
+        self.client.force_login(self.staff_user)
+        response = self.client.get(reverse('app_version'))
+        self.assertEqual(response.status_code, 403)
+
+    def test_correct_template_used(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get(reverse('app_version'))
+        self.assertTemplateUsed(response, 'bookmarks/app_version.html')
+
+    def test_context_contains_build_info(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get(reverse('app_version'))
+        self.assertIn('build_version', response.context)
+        self.assertIn('build_date', response.context)
+        self.assertIn('build_commit', response.context)
+
+    def test_build_version_defaults_to_dev(self):
+        os.environ.pop('BUILD_VERSION', None)
+        self.client.force_login(self.superuser)
+        response = self.client.get(reverse('app_version'))
+        self.assertEqual(response.context['build_version'], 'dev')
+
+    def test_build_version_reads_env_var(self):
+        os.environ['BUILD_VERSION'] = '2.3.4'
+        try:
+            self.client.force_login(self.superuser)
+            response = self.client.get(reverse('app_version'))
+            self.assertEqual(response.context['build_version'], '2.3.4')
+        finally:
+            os.environ.pop('BUILD_VERSION', None)
+
+    def test_context_contains_packages_list(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get(reverse('app_version'))
+        self.assertIn('packages', response.context)
+        self.assertIsInstance(response.context['packages'], list)
+
+    def test_packages_have_required_keys(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get(reverse('app_version'))
+        packages = response.context['packages']
+        if packages:
+            pkg = packages[0]
+            self.assertIn('name', pkg)
+            self.assertIn('required', pkg)
+            self.assertIn('installed', pkg)
+
+    def test_context_title(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get(reverse('app_version'))
+        self.assertEqual(response.context['title'], 'App Version')
+
+
 NODE_MODULES = Path(__file__).parents[3] / 'node_modules'
 
 

--- a/bookmarks/bookmarks/urls.py
+++ b/bookmarks/bookmarks/urls.py
@@ -2,7 +2,7 @@ from django.urls import include, path
 
 from .views import BookmarksList, BookmarkTagList
 from .views import BookmarkCreate, BookmarkUpdate
-from .views import Charts
+from .views import Charts, AppVersion
 
 urlpatterns = [
     path('', BookmarksList.as_view(), name='index'),
@@ -10,4 +10,5 @@ urlpatterns = [
     path('new/', BookmarkCreate.as_view(), name='bookmark_create'),
     path('edit/<int:pk>/', BookmarkUpdate.as_view(), name='bookmark_update'),
     path('charts/', Charts.as_view(), name='charts'),
+    path('version/', AppVersion.as_view(), name='app_version'),
 ]

--- a/bookmarks/bookmarks/views.py
+++ b/bookmarks/bookmarks/views.py
@@ -1,3 +1,7 @@
+import os
+import re
+import importlib.metadata
+
 from django.shortcuts import render, get_object_or_404
 from django.views.generic import FormView
 from django.views.generic import TemplateView, ListView
@@ -5,6 +9,8 @@ from django.views.generic import CreateView, UpdateView
 from django.db.models import Q, Count
 from django.db.models.functions import TruncDate
 from django import forms
+from django.contrib.auth.mixins import UserPassesTestMixin
+from django.conf import settings
 from datetime import datetime, timedelta
 from calendar import month_abbr
 
@@ -128,6 +134,47 @@ class BookmarkUpdate(LoginRequiredMixin, NextOnSuccessMixin, UpdateView):
     model = Bookmark
     form_class = BookmarkForm
     success_url = '/'
+
+
+def _get_package_versions():
+    req_path = os.path.join(settings.PROJECT_ROOT, 'requirements.txt')
+    packages = []
+    try:
+        with open(req_path) as fh:
+            for raw_line in fh:
+                line = raw_line.strip()
+                if not line or line.startswith('#'):
+                    continue
+                if line.startswith('git+') or '://' in line:
+                    packages.append({'name': line, 'required': 'VCS/URL', 'installed': 'N/A'})
+                    continue
+                parts = re.split(r'(==|>=|<=|~=|!=|>|<)', line, maxsplit=1)
+                pkg_name = parts[0].strip()
+                req_spec = ''.join(parts[1:]).strip() if len(parts) > 1 else ''
+                try:
+                    installed = importlib.metadata.version(pkg_name)
+                except importlib.metadata.PackageNotFoundError:
+                    installed = 'not found'
+                packages.append({'name': pkg_name, 'required': req_spec or 'any', 'installed': installed})
+    except FileNotFoundError:
+        pass
+    return packages
+
+
+class AppVersion(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
+    template_name = 'bookmarks/app_version.html'
+
+    def test_func(self):
+        return self.request.user.is_superuser
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['title'] = 'App Version'
+        context['build_version'] = os.environ.get('BUILD_VERSION', 'dev')
+        context['build_date'] = os.environ.get('BUILD_DATE', 'N/A')
+        context['build_commit'] = os.environ.get('BUILD_COMMIT', 'N/A')
+        context['packages'] = _get_package_versions()
+        return context
 
 
 class Charts(TemplateView):

--- a/bookmarks/templates/bookmarks/app_version.html
+++ b/bookmarks/templates/bookmarks/app_version.html
@@ -1,0 +1,51 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="container">
+
+  <div class="row">
+    <div class="col-xs-12">
+      <h2>App Version</h2>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-xs-12">
+      <table class="table table-bordered table-condensed">
+        <tbody>
+          <tr><th class="col-xs-3">Build Version</th><td>{{ build_version }}</td></tr>
+          <tr><th>Build Date</th><td>{{ build_date }}</td></tr>
+          <tr><th>Git Commit</th><td><code>{{ build_commit }}</code></td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-xs-12">
+      <h3>Python Packages</h3>
+      <table class="table table-bordered table-condensed table-striped">
+        <thead>
+          <tr><th>Package</th><th>Required</th><th>Installed</th></tr>
+        </thead>
+        <tbody>
+          {% for pkg in packages %}
+          <tr>
+            <td>{{ pkg.name }}</td>
+            <td><code>{{ pkg.required }}</code></td>
+            <td>
+              {% if pkg.installed == 'not found' or pkg.installed == 'N/A' %}
+                <span class="label label-warning">{{ pkg.installed }}</span>
+              {% else %}
+                {{ pkg.installed }}
+              {% endif %}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+</div>
+{% endblock %}

--- a/bookmarks/templates/bookmarks/navbar.html
+++ b/bookmarks/templates/bookmarks/navbar.html
@@ -41,6 +41,7 @@
             </a>
             <ul class="dropdown-menu dropdown-menu-right">
               {% if user.is_staff %}<li><a href="{% url 'admin:index' %}">Admin</a></li>{% endif %}
+              {% if user.is_superuser %}<li><a href="{% url 'app_version' %}">App Version</a></li>{% endif %}
               <li><a href="{% url 'log_out' %}">Log Out</a></li>
             </ul>
           </li>


### PR DESCRIPTION
Adds a /version/ page showing build metadata (version, date, git commit)
injected at Docker build time, and a runtime inspection of installed Python
package versions. A nav link is added to the authenticated user dropdown,
visible only to superusers.

- AppVersion view uses UserPassesTestMixin to enforce superuser access
- Build info read from BUILD_VERSION, BUILD_DATE, BUILD_COMMIT env vars
  with 'dev'/'N/A' fallbacks when running locally
- Package versions resolved at runtime via importlib.metadata
- Dockerfile ARG/ENV added to bake build info into the image
- CI workflow updated to pass --build-arg values to docker build

https://claude.ai/code/session_01NwjQBdnyH7rYhoYBS4q1mM