### PR TITLE
Update django to 6.0.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image with python dependencies
-FROM python:3.10-slim-bullseye as base
+FROM python:3.12-slim-bullseye as base
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 RUN apt-get update && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==5.1.3
+Django==6.0.5
 six==1.16.0
 sqlparse==0.5.5
 


### PR DESCRIPTION
Replaces #346 with a clean rebase onto current master.\n\nUpdates [Django](https://pypi.org/project/Django) from **5.1.3** to **6.0.5** and bumps the Python base image in the Dockerfile from **3.10** to **3.12** (required for Django 6.0).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUPPRiJRgf5SFsMEwBbJPC)_