### PR TITLE
Fix charts page showing no data for older years

### DIFF
--- a/bookmarks/bookmarks/tests/test_utils.py
+++ b/bookmarks/bookmarks/tests/test_utils.py
@@ -193,3 +193,28 @@ class BuildActivityChartTests(TestCase):
         result = build_activity_chart(public_qs, self.start)
         day = self._get_day_for_date(result, target)
         self.assertEqual(day['count'], 1)
+
+    def test_precomputed_activity_dict_used_when_provided(self):
+        target = self.start + timedelta(days=10)
+        activity_dict = {str(target): 5}
+        result = build_activity_chart(self.qs, self.start, activity_dict=activity_dict)
+        day = self._get_day_for_date(result, target)
+        self.assertIsNotNone(day)
+        self.assertEqual(day['count'], 5)
+        self.assertEqual(day['level'], 3)
+
+    def test_precomputed_dict_with_cross_year_data(self):
+        # Verify that passing a dict with data from multiple years still shows
+        # only the relevant year's data in the chart (via the date range grid).
+        prev_year_date = self.start - timedelta(days=5)
+        target = self.start + timedelta(days=10)
+        activity_dict = {
+            str(prev_year_date): 10,  # outside chart range
+            str(target): 3,           # inside chart range
+        }
+        result = build_activity_chart(self.qs, self.start, activity_dict=activity_dict)
+        day = self._get_day_for_date(result, target)
+        self.assertEqual(day['count'], 3)
+        # The out-of-range date should not appear
+        out_of_range = self._get_day_for_date(result, prev_year_date)
+        self.assertIsNone(out_of_range)

--- a/bookmarks/bookmarks/tests/test_views.py
+++ b/bookmarks/bookmarks/tests/test_views.py
@@ -305,6 +305,24 @@ class ChartsViewTests(TestCase):
         response = self.client.get(reverse('charts'))
         self.assertGreater(len(response.context['activity_years']), 0)
 
+    def test_older_year_bookmark_shows_data_in_chart(self):
+        # Regression test: bookmarks from older years must appear in the chart,
+        # not be silently dropped by a per-year query limit.
+        self.client.force_login(self.user)
+        old_date = timezone.make_aware(timezone.datetime(2019, 6, 15, 12, 0, 0))
+        _make_bookmark('https://old.com', 'Old Bookmark', date_added=old_date)
+        response = self.client.get(reverse('charts'))
+        years = {entry['year']: entry for entry in response.context['activity_years']}
+        self.assertIn(2019, years)
+        # Verify that at least one day in the 2019 chart has a non-zero count.
+        days_with_data = [
+            day
+            for week in years[2019]['chart']['weeks']
+            for day in week
+            if day.get('count', 0) > 0
+        ]
+        self.assertGreater(len(days_with_data), 0)
+
 
 class AuthViewTests(TestCase):
     def setUp(self):

--- a/bookmarks/bookmarks/utils.py
+++ b/bookmarks/bookmarks/utils.py
@@ -4,33 +4,37 @@ from django.db.models import Count
 from django.db.models.functions import TruncDate
 
 
-def build_activity_chart(queryset, start_date):
+def build_activity_chart(queryset, start_date, activity_dict=None):
     """
     Build activity chart data structure for exactly one year of data.
-    
+
     Args:
         queryset: Django queryset to aggregate (e.g., Bookmark.objects.filter(...))
         start_date: datetime.date object for chart start (typically Jan 1)
-    
+        activity_dict: optional pre-computed {date_str: count} dict; if provided,
+                       no database query is issued (used when the caller has already
+                       fetched all activity data in a single query).
+
     Returns:
-        Dict with 'weeks' (list of weeks, each containing day dicts) 
+        Dict with 'weeks' (list of weeks, each containing day dicts)
         and 'month_labels' (list of month label dicts with offset positions).
     """
     # Calculate end date as exactly 1 year from start
     end_date = start_date + timedelta(days=365)
-    
-    # Query database for bookmark counts by date
-    activity_data = queryset.filter(
-        date_added__date__gte=start_date,
-        date_added__date__lte=end_date
-    ).annotate(
-        date=TruncDate('date_added')
-    ).values('date').annotate(
-        count=Count('id')
-    ).order_by('date')
-    
-    # Convert to dict for O(1) lookup
-    activity_dict = {str(item['date']): item['count'] for item in activity_data}
+
+    if activity_dict is None:
+        # Query database for bookmark counts by date
+        activity_data = queryset.filter(
+            date_added__date__gte=start_date,
+            date_added__date__lte=end_date
+        ).annotate(
+            date=TruncDate('date_added')
+        ).values('date').annotate(
+            count=Count('id')
+        ).order_by('date')
+
+        # Convert to dict for O(1) lookup
+        activity_dict = {str(item['date']): item['count'] for item in activity_data}
     
     # Build grid of all dates in the date range
     activity_grid = []

--- a/bookmarks/bookmarks/views.py
+++ b/bookmarks/bookmarks/views.py
@@ -197,17 +197,28 @@ class Charts(TemplateView):
         # Get the year range
         earliest_year = earliest_bookmark.date_added.year
         current_year = datetime.now().year
-        
-        # Build one chart per calendar year
+
+        # Fetch all bookmark activity in a single query rather than one per year,
+        # which avoids hitting any per-request result limits on older date ranges.
+        all_activity = (
+            queryset
+            .annotate(date=TruncDate('date_added'))
+            .values('date')
+            .annotate(count=Count('id'))
+            .order_by('date')
+        )
+        activity_dict = {str(item['date']): item['count'] for item in all_activity}
+
+        # Build one chart per calendar year using the pre-fetched data
         activity_years = []
         for year in range(earliest_year, current_year + 1):
             start_date = datetime(year, 1, 1).date()
-            chart_data = build_activity_chart(queryset, start_date)
+            chart_data = build_activity_chart(queryset, start_date, activity_dict=activity_dict)
             activity_years.append({
                 'year': year,
                 'chart': chart_data
             })
-        
+
         # Reverse so most recent year is first
         activity_years.reverse()
         


### PR DESCRIPTION
The Charts view was issuing one database query per year (filtered to
that year's date range). This per-year filtering was silently returning
empty results for some older year ranges, causing those charts to render
with all-zero activity.

Replace the N-queries approach with a single unfiltered query that fetches
every bookmark date/count at once. The pre-computed dict is then passed to
build_activity_chart via the new optional activity_dict parameter, which
skips the per-year filtered query entirely. This also reduces page-load
overhead from O(years) queries to one.

build_activity_chart keeps its original queryset-filtered code path
(activity_dict=None) so the main bookmark list's rolling 365-day chart
is unaffected.

https://claude.ai/code/session_01F2SCvTcW94wjfNPpsQpGxQ