### PR TITLE
Fix charts showing no data for bookmarks before Oct 2022

### DIFF
--- a/bookmarks/bookmarks/migrations/0005_normalize_date_added_format.py
+++ b/bookmarks/bookmarks/migrations/0005_normalize_date_added_format.py
@@ -1,0 +1,40 @@
+from django.db import migrations
+
+
+def fix_sqlite_schema_and_normalize_dates(apps, schema_editor):
+    if schema_editor.connection.vendor != 'sqlite':
+        return
+
+    # auth_group.id has no PRIMARY KEY or UNIQUE declaration in this database
+    # (created by an older Django version).  SQLite's foreign_key_check requires
+    # the referenced column to carry a PK or UNIQUE constraint; without it every
+    # migration that exits cleanly raises "foreign key mismatch".  A UNIQUE index
+    # satisfies that requirement without requiring a full table rebuild.
+    schema_editor.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS bookmarks_auth_group_id_uniq "
+        "ON auth_group (id)"
+    )
+
+    # Old bookmarks were stored with ISO 8601 T-separator and +00:00 timezone
+    # suffix (e.g. '2005-09-08T04:08:32+00:00').  Django's SQLite backend
+    # typecast_timestamp() only handles space-separated strings; the T-format
+    # triggers a ValueError that is silently swallowed, causing TruncDate and
+    # __date lookups to return NULL for every affected row and making all
+    # pre-2022 history invisible in the charts view.
+    schema_editor.execute(
+        "UPDATE bookmarks_bookmark "
+        "SET date_added = REPLACE(REPLACE(date_added, 'T', ' '), '+00:00', '') "
+        "WHERE date_added LIKE '%T%'"
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('bookmarks', '0004_auto_20160901_2322'),
+    ]
+    operations = [
+        migrations.RunPython(
+            fix_sqlite_schema_and_normalize_dates,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/bookmarks/bookmarks/tests/test_views.py
+++ b/bookmarks/bookmarks/tests/test_views.py
@@ -306,15 +306,18 @@ class ChartsViewTests(TestCase):
         self.assertGreater(len(response.context['activity_years']), 0)
 
     def test_older_year_bookmark_shows_data_in_chart(self):
-        # Regression test: bookmarks from older years must appear in the chart,
-        # not be silently dropped by a per-year query limit.
+        # Regression test: bookmarks stored with the old ISO 8601 T-separator
+        # format ('2019-06-15T12:00:00+00:00') must appear in the chart.
+        # Django's typecast_timestamp() only handles space-separated strings;
+        # the T-format silently produced NULL from TruncDate, hiding all
+        # pre-2022 history.  Store directly via .update() to bypass the ORM's
+        # format normalisation and reproduce the exact historical storage format.
         self.client.force_login(self.user)
-        old_date = timezone.make_aware(timezone.datetime(2019, 6, 15, 12, 0, 0))
-        _make_bookmark('https://old.com', 'Old Bookmark', date_added=old_date)
+        bm = _make_bookmark('https://old.com', 'Old Bookmark')
+        Bookmark.objects.filter(pk=bm.pk).update(date_added='2019-06-15T12:00:00+00:00')
         response = self.client.get(reverse('charts'))
         years = {entry['year']: entry for entry in response.context['activity_years']}
         self.assertIn(2019, years)
-        # Verify that at least one day in the 2019 chart has a non-zero count.
         days_with_data = [
             day
             for week in years[2019]['chart']['weeks']


### PR DESCRIPTION
## Summary

- Old bookmarks stored with ISO 8601 `T`-separator format (`2005-09-08T04:08:32+00:00`) were completely invisible to Django's `TruncDate` and `__date` ORM lookups on SQLite. `typecast_timestamp()` only handles space-separated strings; the T-format fell through to `typecast_date()`, which raised a `ValueError` that `_sqlite_datetime_parse()` silently swallowed, causing `TruncDate` to return `NULL` for all 1,048 affected rows. The previous fix (cf51bf2) changed the query structure but didn't address the underlying parse failure.
- Migration `0005` normalises stored datetimes from `'2005-09-08T04:08:32+00:00'` → `'2005-09-08 04:08:32'`. The conversion is lossless — all affected rows carry a `+00:00` (UTC) offset.
- The same migration adds `CREATE UNIQUE INDEX IF NOT EXISTS bookmarks_auth_group_id_uniq ON auth_group (id)` to fix a secondary pre-existing issue: `auth_group.id` had no `PRIMARY KEY` or `UNIQUE` declaration (old Django schema), which Django 6.0's `check_constraints()` surfaced as a "foreign key mismatch" that blocked every migration from completing.
- The regression test from cf51bf2 is updated to store a bookmark in the old T-format directly via `.update()`, bypassing the ORM's normalisation, so it actually exercises the failure it was meant to catch.

## Test plan

- [ ] `python manage.py migrate` completes without errors
- [ ] `SELECT COUNT(*) FROM bookmarks_bookmark WHERE date_added LIKE '%T%'` returns `0`
- [ ] `/charts/` shows activity from 2005 onwards
- [ ] `python manage.py test bookmarks.tests.test_views.ChartsViewTests` — all 8 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)