### PR TITLE
Upgrade Bootstrap 3.4.1 → 5.3 with plugin replacements

### DIFF
--- a/bookmarks/bookmarks/templates/bookmarks/bookmark_list.html
+++ b/bookmarks/bookmarks/templates/bookmarks/bookmark_list.html
@@ -7,20 +7,20 @@
 <div class="container">
 
   <div class="row">
-    <div class="col-xs-12">
+    <div class="col-12">
       {% include 'bookmarks/activity_chart.html' %}
     </div>
   </div>
 
   {% for bookmark in bookmarks %}
   <div class="row bookmark">
-    <div class="col-xs-12">
+    <div class="col-12">
       <h4><a href="{{bookmark.url}}">{{bookmark.title}}</a>
       {% if bookmark.date_added %}
         <small>{{bookmark.date_added}}
         {% if user.is_staff %}
           <span class="admin-menu fade">
-          <a href="{% url 'bookmark_update' bookmark.id %}?{% url_replace request 'next' request.get_full_path %}"><span class="glyphicon glyphicon-cog" aria-hidden="true"></span></a>
+          <a href="{% url 'bookmark_update' bookmark.id %}?{% url_replace request 'next' request.get_full_path %}"><span class="fa fa-cog" aria-hidden="true"></span></a>
           </span>
         {% endif %}
         </small>
@@ -29,62 +29,64 @@
       {% if bookmark.description %}
         {{bookmark.description | render_markdown}}
       {%endif%}
-      {% if bookmark.private %}<span class="label label-warning">private</span>{% endif %}
+      {% if bookmark.private %}<span class="badge bg-warning text-dark">private</span>{% endif %}
       {% for tag in bookmark.tags.all %}
-        <a href="{% url 'tag' tag.slug %}" class="tag label
+        <a href="{% url 'tag' tag.slug %}" class="tag badge
         {% if tag.slug == tag_filter %}
-          label-primary
+          bg-primary
         {% elif search|lower in tag.name %}
-          label-success
+          bg-success
         {% else %}
-          label-default
+          bg-secondary
         {% endif %}
-        ">{{tag.name}}</a> 
+        ">{{tag.name}}</a>
       {% endfor %}
       <br /><br />
     </div>
-  </div>  
+  </div>
   {% endfor %}
 
 
 
   <div class="row">
-    <div class="col-xs-12">
+    <div class="col-12">
       {% include 'bookmarks/pagination-reverse.html' %}
     </div>
-  </div>  
+  </div>
 
 </div>
 
 
-<form action="" method="get" class="form-horizontal modal fade" id="filter-form">
+<form action="" method="get" class="modal fade" id="filter-form">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-        <h4 class="modal-title">Filter</h4>
+        <h5 class="modal-title">Filter</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
 
-        <div class="form-group">
-          <label class="col-sm-3 control-label" for="date-range-select">Date Added</label>
-          <div class="col-sm-9 input-daterange input-group" id="date-added-range-select">
-            <input type="text" class="form-control" name="date_added_from" placeholder="From" 
-              {% if date_added_from %}
-                value="{{date_added_from}}"
-              {% endif %}>
-            <span class="input-group-addon">to</span>
-            <input type="text" class="form-control" name="date_added_to" placeholder="To" 
-              {% if date_added_to %}
-                value="{{date_added_to}}"
-              {% endif %}>
+        <div class="mb-3 row">
+          <label class="col-sm-3 col-form-label" for="date-added-range-select">Date Added</label>
+          <div class="col-sm-9">
+            <div class="input-group">
+              <input type="text" class="form-control" id="date-added-from" name="date_added_from" placeholder="From"
+                {% if date_added_from %}
+                  value="{{date_added_from}}"
+                {% endif %}>
+              <span class="input-group-text">to</span>
+              <input type="text" class="form-control" id="date-added-to" name="date_added_to" placeholder="To"
+                {% if date_added_to %}
+                  value="{{date_added_to}}"
+                {% endif %}>
+            </div>
           </div>
         </div>
 
       </div>
       <div class="modal-footer">
-        <a type="button" class="btn btn-default" data-dismiss="modal">Cancel</a>
-        <a id="reset" type="button" class="btn btn-default">Reset</a>
+        <a type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</a>
+        <a id="reset" type="button" class="btn btn-secondary">Reset</a>
         <button type="submit" class="btn btn-primary">Apply</button>
       </div>
     </div>
@@ -94,10 +96,10 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="{% static 'npm/bootstrap-datepicker/dist/js/bootstrap-datepicker.min.js' %}"></script>
+<script src="{% static 'npm/flatpickr/dist/flatpickr.min.js' %}"></script>
 <script language="javascript">
   $(document).ready(function(){
-    
+
     // Add click handlers for activity days
     $('.activity-day[data-date]').on('click', function() {
       var date = $(this).data('date');
@@ -122,18 +124,23 @@
                 this.checked = false;
         }
       });
+      if (window._flatpickrFrom) window._flatpickrFrom.clear();
+      if (window._flatpickrTo) window._flatpickrTo.clear();
     });
 
-    var today = new Date();
-    $('#date-added-range-select').datepicker({
-      format: "yyyy-mm-dd",
-      endDate: today,
+    window._flatpickrFrom = flatpickr('#date-added-from', {
+      dateFormat: "Y-m-d",
+      maxDate: "today",
+    });
+    window._flatpickrTo = flatpickr('#date-added-to', {
+      dateFormat: "Y-m-d",
+      maxDate: "today",
     });
 
     $(".bookmark").hover(
       function () {
         $(this).find('.admin-menu').removeClass('fade');
-      }, 
+      },
       function () {
         $(this).find('.admin-menu').addClass('fade');
       }

--- a/bookmarks/bookmarks/templates/bookmarks/charts.html
+++ b/bookmarks/bookmarks/templates/bookmarks/charts.html
@@ -6,7 +6,7 @@
 <div class="container">
     {% for year_data in activity_years %}
     <div class="row">
-        <div class="col-xs-12">
+        <div class="col-12">
           <h3>{{ year_data.year }}</h3>
           {% with activity_chart=year_data.chart %}
             {% include "bookmarks/activity_chart.html" %}

--- a/bookmarks/bookmarks/templates/bookmarks/pagination-reverse.html
+++ b/bookmarks/bookmarks/templates/bookmarks/pagination-reverse.html
@@ -1,14 +1,17 @@
 {% load template_extras %}
 
-<nav>
-  <ul class="pager">
+<nav aria-label="Page navigation">
+  <ul class="pagination">
     {% if page_obj.has_next %}
-      <li class="previous"><a href="?{% url_replace request 'page' page_obj.next_page_number %}"><span aria-hidden="true">&larr;</span> Older</a></li>
+      <li class="page-item">
+        <a class="page-link" href="?{% url_replace request 'page' page_obj.next_page_number %}">&larr; Older</a>
+      </li>
     {% endif %}
 
     {% if page_obj.has_previous %}
-      <li class="next"><a href="?{% url_replace request 'page' page_obj.previous_page_number %}">Newer <span aria-hidden="true">&rarr;</span></a></li>
+      <li class="page-item">
+        <a class="page-link" href="?{% url_replace request 'page' page_obj.previous_page_number %}">Newer &rarr;</a>
+      </li>
     {% endif %}
   </ul>
 </nav>
-

--- a/bookmarks/bookmarks/templates/bookmarks/pagination.html
+++ b/bookmarks/bookmarks/templates/bookmarks/pagination.html
@@ -1,14 +1,17 @@
 {% load template_extras %}
 
-<nav>
-  <ul class="pager">
+<nav aria-label="Page navigation">
+  <ul class="pagination">
     {% if page_obj.has_previous %}
-      <li class="previous"><a href="?{% url_replace request 'page' page_obj.previous_page_number %}"><span aria-hidden="true">&larr;</span> Previous</a></li>
+      <li class="page-item">
+        <a class="page-link" href="?{% url_replace request 'page' page_obj.previous_page_number %}">&larr; Previous</a>
+      </li>
     {% endif %}
 
     {% if page_obj.has_next %}
-      <li class="next"><a href="?{% url_replace request 'page' page_obj.next_page_number %}">Next <span aria-hidden="true">&rarr;</span></a></li>
+      <li class="page-item">
+        <a class="page-link" href="?{% url_replace request 'page' page_obj.next_page_number %}">Next &rarr;</a>
+      </li>
     {% endif %}
   </ul>
 </nav>
-

--- a/bookmarks/config/settings/base.py
+++ b/bookmarks/config/settings/base.py
@@ -148,21 +148,18 @@ NPM_STATIC_FILES_PREFIX = 'npm'
 NPM_FILE_PATTERNS = {
     'bootstrap': [
         'dist/css/*.min.*',
-        'dist/fonts/*',
-        'dist/js/*.min.*',
-    ],
-    'bootstrap-datepicker': [
-        'dist/css/*.min.*',
-        'dist/js/*.min.*',
-        'dist/locales/*',
-    ],
-    'bootstrap-tokenfield': [
-        'dist/*.min.js',
-        'dist/css/*.min.css',
+        'dist/js/bootstrap.bundle.min.*',
     ],
     'bootswatch': [
-        'slate/bootstrap.min.css',
-        'fonts/*',
+        'dist/slate/bootstrap.min.css',
+    ],
+    '@yaireo/tagify': [
+        'dist/tagify.js',
+        'dist/tagify.css',
+    ],
+    'flatpickr': [
+        'dist/flatpickr.min.js',
+        'dist/flatpickr.min.css',
     ],
     'font-awesome': [
         'css/*.min.*',
@@ -170,9 +167,6 @@ NPM_FILE_PATTERNS = {
     ],
     'jquery': [
         'dist/jquery.min.js',
-    ],
-    'typeahead.js': [
-        'dist/typeahead.bundle.min.js',
     ],
 }
 

--- a/bookmarks/config/static/css/bookmarks.css
+++ b/bookmarks/config/static/css/bookmarks.css
@@ -12,78 +12,49 @@ h4 small {
 
 /* Overrides for dark mode */
 @media (prefers-color-scheme: dark) {
-    .label-primary {
-        background-color: #337ab7;
+    .badge.bg-primary {
+        background-color: #337ab7 !important;
     }
 
-    .label-primary[href]:hover,
-    .label-primary[href]:focus {
-        background-color: #286090;
+    .badge.bg-primary:hover,
+    .badge.bg-primary:focus {
+        background-color: #286090 !important;
     }
 
     .navbar {
         background-image: none;
     }
+
+    .tagify {
+        --tag-bg: #3a3f44;
+        --tag-text-color: #c8c8c8;
+        --tag-border-color: #555;
+    }
+
+    .tagify__dropdown {
+        background: #272b30;
+        border-color: #3a3f44;
+    }
+
+    .tagify__dropdown__item {
+        color: #c8c8c8;
+    }
+
+    .tagify__dropdown__item--active {
+        background: #3a3f44;
+    }
 }
 
-.twitter-typeahead .tt-query,
-.twitter-typeahead .tt-hint {
-    margin-bottom: 0;
+a.tag.badge {
+    text-decoration: none;
 }
 
-.twitter-typeahead .tt-hint
-{
-    display: none;
+a.tag.badge.bg-secondary {
+    background-color: #999 !important;
 }
 
-.tt-menu {
-    position: absolute;
-    top: 100%;
-    left: 0;
-    z-index: 1000;
-    display: none;
-    float: left;
-    min-width: 160px;
-    padding: 5px 0;
-    margin: 2px 0 0;
-    list-style: none;
-    font-size: 14px;
-    background-color: #ffffff;
-    border: 1px solid #cccccc;
-    border: 1px solid rgba(0, 0, 0, 0.15);
-    border-radius: 4px;
-    -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
-    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
-    background-clip: padding-box;
-    cursor: pointer;
-}
-
-.tt-suggestion {
-    display: block;
-    padding: 3px 20px;
-    clear: both;
-    font-weight: normal;
-    line-height: 1.428571429;
-    color: #333333;
-    white-space: nowrap;
-}
-
-.tt-suggestion:hover,
-.tt-suggestion:focus {
-  color: #ffffff;
-  text-decoration: none;
-  outline: 0;
-  background-color: #428bca;
-}
-
-.input-daterange[class*=col-] {
-    width: 75%;
-    padding-left: 15px;
-    padding-right: 15px;
-}
-
-a.tag.label-default {
-    background-color: #999;
+a.tag.badge:hover {
+    opacity: 0.85;
 }
 
 /* Activity Chart Styles */
@@ -165,23 +136,23 @@ a.tag.label-default {
     border: 1px solid #337ab7;
 }
 
-@media (prefers-color-scheme: dark) {    
+@media (prefers-color-scheme: dark) {
     .activity-day.level-0 {
         background-color: #161b22;
     }
-    
+
     .activity-day.level-1 {
         background-color: #0a3d62;
     }
-    
+
     .activity-day.level-2 {
         background-color: #1e5f8c;
     }
-    
+
     .activity-day.level-3 {
         background-color: #2874a6;
     }
-    
+
     .activity-day.level-4 {
         background-color: #3498db;
     }

--- a/bookmarks/templates/bookmarks/app_version.html
+++ b/bookmarks/templates/bookmarks/app_version.html
@@ -4,16 +4,16 @@
 <div class="container">
 
   <div class="row">
-    <div class="col-xs-12">
+    <div class="col-12">
       <h2>App Version</h2>
     </div>
   </div>
 
   <div class="row">
-    <div class="col-xs-12">
-      <table class="table table-bordered table-condensed">
+    <div class="col-12">
+      <table class="table table-bordered table-sm">
         <tbody>
-          <tr><th class="col-xs-3">Build Version</th><td>{{ build_version }}</td></tr>
+          <tr><th class="col-3">Build Version</th><td>{{ build_version }}</td></tr>
           <tr><th>Build Date</th><td>{{ build_date }}</td></tr>
           <tr><th>Git Commit</th><td><code>{{ build_commit }}</code></td></tr>
         </tbody>
@@ -22,9 +22,9 @@
   </div>
 
   <div class="row">
-    <div class="col-xs-12">
+    <div class="col-12">
       <h3>Python Packages</h3>
-      <table class="table table-bordered table-condensed table-striped">
+      <table class="table table-bordered table-sm table-striped">
         <thead>
           <tr><th>Package</th><th>Required</th><th>Installed</th></tr>
         </thead>
@@ -35,7 +35,7 @@
             <td><code>{{ pkg.required }}</code></td>
             <td>
               {% if pkg.installed == 'not found' or pkg.installed == 'N/A' %}
-                <span class="label label-warning">{{ pkg.installed }}</span>
+                <span class="badge bg-warning text-dark">{{ pkg.installed }}</span>
               {% else %}
                 {{ pkg.installed }}
               {% endif %}

--- a/bookmarks/templates/bookmarks/head.html
+++ b/bookmarks/templates/bookmarks/head.html
@@ -10,18 +10,11 @@
 
 <!-- Styles -->
 <link href="{% static 'npm/bootstrap/dist/css/bootstrap.min.css' %}" rel="stylesheet" media="(prefers-color-scheme: light)">
-<link href="{% static 'npm/bootswatch/slate/bootstrap.min.css' %}" rel="stylesheet" media="(prefers-color-scheme: dark)">
+<link href="{% static 'npm/bootswatch/dist/slate/bootstrap.min.css' %}" rel="stylesheet" media="(prefers-color-scheme: dark)">
 <link href="{% static 'npm/font-awesome/css/font-awesome.min.css' %}" rel="stylesheet">
-<link href="{% static 'npm/bootstrap-tokenfield/dist/css/bootstrap-tokenfield.min.css' %}" rel="stylesheet">
-<link href="{% static 'npm/bootstrap-datepicker/dist/css/bootstrap-datepicker3.min.css' %}" rel="stylesheet">
+<link href="{% static 'npm/@yaireo/tagify/dist/tagify.css' %}" rel="stylesheet">
+<link href="{% static 'npm/flatpickr/dist/flatpickr.min.css' %}" rel="stylesheet">
 <link href="{% static 'css/bookmarks.css' %}" rel="stylesheet">
-
-<!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
-<!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
-<!--[if lt IE 9]>
-<script src="//oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
-<script src="//oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
-<![endif]-->
 
 <link rel="apple-touch-icon" sizes="57x57" href="{% static 'images/favicons/apple-icon-57x57.png' %}">
 <link rel="apple-touch-icon" sizes="60x60" href="{% static 'images/favicons/apple-icon-60x60.png' %}">

--- a/bookmarks/templates/bookmarks/navbar.html
+++ b/bookmarks/templates/bookmarks/navbar.html
@@ -1,52 +1,44 @@
 {% load template_extras %}
 
-<nav class="navbar navbar-default navbar-fixed-top" role="navigation">
+<nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top" role="navigation">
   <div class="container-fluid">
-    <div class="navbar-header">
-      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
-        <span class="sr-only">Toggle navigation</span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-      </button>
-      <a class="navbar-brand" href="{% url 'index' %}">📘 Bookmarks</a>
-      {% if tag_filter %}<p class="navbar-text">{{tag_filter.name}}</p>{% endif %}
-    </div>
+    <a class="navbar-brand" href="{% url 'index' %}">📘 Bookmarks</a>
+    {% if tag_filter %}<span class="navbar-text me-2">{{tag_filter.name}}</span>{% endif %}
+    <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#navbar-collapse" aria-controls="navbar-collapse" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
 
-    <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-      <ul class="nav navbar-nav pull-right">
+    <div class="collapse navbar-collapse" id="navbar-collapse">
+      <ul class="navbar-nav ms-auto">
 
-        <li>
-          <form class="navbar-form navbar-right" action="." method="get" role="search">
-            <div class="form-group">
-              <input type="text" class="form-control" name="search" placeholder="Search..." {% if request.GET.search %}value="{{request.GET.search}}"{% endif %}>
-            </div>
-          </form> 
+        <li class="nav-item">
+          <form class="d-flex me-2" action="." method="get" role="search">
+            <input type="text" class="form-control" name="search" placeholder="Search..." {% if request.GET.search %}value="{{request.GET.search}}"{% endif %}>
+          </form>
         </li>
 
         {% if user.is_authenticated %}
-          <li><a href="{% url 'bookmark_create' %}?{% url_replace request 'next' request.get_full_path %}">Add</a></li>
+          <li class="nav-item"><a class="nav-link" href="{% url 'bookmark_create' %}?{% url_replace request 'next' request.get_full_path %}">Add</a></li>
         {% endif %}
 
-        <li><a href="#" data-toggle="modal" data-target="#filter-form">Filter</a></li>
-        <li><a href="{% url 'charts' %}">Charts</a></li>
+        <li class="nav-item"><a class="nav-link" href="#" data-bs-toggle="modal" data-bs-target="#filter-form">Filter</a></li>
+        <li class="nav-item"><a class="nav-link" href="{% url 'charts' %}">Charts</a></li>
 
         {% if user.is_authenticated %}
-          <li class="dropdown">
-            <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+          <li class="nav-item dropdown">
+            <a href="#" class="nav-link dropdown-toggle" data-bs-toggle="dropdown">
               {% if user.first_name and user.last_name %}{{ user.first_name }} {{ user.last_name }}
               {% elif user.email %}{{ user.email }}
               {% else %}{{ user.username }}{% endif %}
-              &nbsp;<b class="caret"></b>
             </a>
-            <ul class="dropdown-menu dropdown-menu-right">
-              {% if user.is_staff %}<li><a href="{% url 'admin:index' %}">Admin</a></li>{% endif %}
-              {% if user.is_superuser %}<li><a href="{% url 'app_version' %}">App Version</a></li>{% endif %}
-              <li><a href="{% url 'log_out' %}">Log Out</a></li>
+            <ul class="dropdown-menu dropdown-menu-end">
+              {% if user.is_staff %}<li><a class="dropdown-item" href="{% url 'admin:index' %}">Admin</a></li>{% endif %}
+              {% if user.is_superuser %}<li><a class="dropdown-item" href="{% url 'app_version' %}">App Version</a></li>{% endif %}
+              <li><a class="dropdown-item" href="{% url 'log_out' %}">Log Out</a></li>
             </ul>
           </li>
         {% else %}
-          <li><a href="{% url 'log_in' %}">Log In</a></li>
+          <li class="nav-item"><a class="nav-link" href="{% url 'log_in' %}">Log In</a></li>
         {% endif %}
 
       </ul>

--- a/bookmarks/templates/bookmarks/tail.html
+++ b/bookmarks/templates/bookmarks/tail.html
@@ -1,6 +1,5 @@
 {% load static %}
 
 <script src="{% static 'npm/jquery/dist/jquery.min.js' %}"></script>
-<script src="{% static 'npm/bootstrap/dist/js/bootstrap.min.js' %}"></script>
-<script src="{% static 'npm/bootstrap-tokenfield/dist/bootstrap-tokenfield.min.js' %}"></script>
-<script src="{% static 'npm/typeahead.js/dist/typeahead.bundle.min.js' %}"></script>
+<script src="{% static 'npm/bootstrap/dist/js/bootstrap.bundle.min.js' %}"></script>
+<script src="{% static 'npm/@yaireo/tagify/dist/tagify.js' %}"></script>

--- a/bookmarks/templates/form_view.html
+++ b/bookmarks/templates/form_view.html
@@ -5,28 +5,28 @@
 
 {% block content %}
 
-<form class="container form-horizontal" role="form" method="post" action".">
+<form class="container" role="form" method="post" action".">
   {% csrf_token %}
 
   <div class="row">
-    <div class="col-xs-12">
+    <div class="col-12">
       <h4>{{ subheading }}</h4>
 
       {% for field in form %}
 
-      <div class="form-group {% if field.errors %}has-error{% endif %}">
+      <div class="mb-3 row {% if field.errors %}is-invalid{% endif %}">
 
-        <label for="{{field.id_for_label}}" class="col-xs-4 col-sm-3 control-label">
+        <label for="{{field.id_for_label}}" class="col-4 col-sm-3 col-form-label">
           {{ field.label|title }}
         </label>
 
-        <div class="col-xs-6">
+        <div class="col-6">
           {% if field|field_type != "CheckboxInput" %}
             {{ field }}
           {% else %}
             <ul class="list-unstyled">
               {% for checkbox in field %}
-              <li class="checkbox">{{ checkbox }}</li>
+              <li class="form-check">{{ checkbox }}</li>
               {% endfor %}
             </ul>
           {% endif %}
@@ -37,9 +37,9 @@
       {% endfor %}
 
       <div class="row">
-        <div class="col-xs-12">
-          <div class="form-group">
-            <div class="col-xs-offset-4 col-sm-offset-3 col-xs-4">
+        <div class="col-12">
+          <div class="mb-3 row">
+            <div class="offset-4 offset-sm-3 col-4">
               <button type="submit" class="btn btn-primary">
                 {% if submit_button_label %}
                   {{ submit_button_label }}
@@ -59,22 +59,20 @@
 
 {% block scripts %}
 <script>
-var bloodhound = new Bloodhound({
-  datumTokenizer: Bloodhound.tokenizers.obj.whitespace('name'),
-  queryTokenizer: Bloodhound.tokenizers.whitespace,
-  prefetch: {
-    url: '/api/tags/?format=json',
-    cache: false,
-  }
-});
-bloodhound.initialize();
+var tagsInput = document.querySelector('input[data-role=tagsinput]');
+if (tagsInput) {
+  var initialValue = tagsInput.value;
+  var tagify = new Tagify(tagsInput, {
+    enforceWhitelist: false,
+    dropdown: { enabled: 1, maxItems: 20, closeOnSelect: false },
+    originalInputValueFormat: function(values) {
+      return values.map(function(v) { return v.value; }).join(', ');
+    }
+  });
 
-$('input[data-role=tagsinput]').tokenfield({
-  typeahead: {
-    displayKey: 'name',
-    valueKey: 'name',
-    source: bloodhound.ttAdapter()
-  }
-});
+  fetch('/api/tags/?format=json')
+    .then(function(r) { return r.json(); })
+    .then(function(data) { tagify.settings.whitelist = data.map(function(t) { return t.name; }); });
+}
 </script>
 {% endblock %}

--- a/bookmarks/templates/registration/login.html
+++ b/bookmarks/templates/registration/login.html
@@ -5,8 +5,8 @@
 
   {% if form.errors %}
   <div class="row">
-    <div class="col-md-offset-3 col-md-6 alert alert-warning alert-dismissable">
-      <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+    <div class="col-md-6 offset-md-3 alert alert-warning alert-dismissible">
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
       {% for error in form.non_field_errors %}
       <p><strong>Oops:</strong> {{ error }}</p>
       {% endfor %}
@@ -16,28 +16,28 @@
 
 
   <div class="row">
-    <div class="col-md-offset-3 col-md-6">
+    <div class="col-md-6 offset-md-3">
 
-      <form class="form-horizontal" role="form" method="post" action="{% url 'log_in' %}">
+      <form role="form" method="post" action="{% url 'log_in' %}">
         {% csrf_token %}
 
-        <div class="form-group">
-          <label for="username" class="col-md-2 control-label">Username</label>
+        <div class="mb-3 row">
+          <label for="username" class="col-md-2 col-form-label">Username</label>
           <div class="col-md-10">
             <input type="text" class="form-control" id="username" name="username" placeholder="Username">
           </div>
         </div>
 
-        <div class="form-group">
-          <label for="password" class="col-md-2 control-label">Password</label>
+        <div class="mb-3 row">
+          <label for="password" class="col-md-2 col-form-label">Password</label>
           <div class="col-md-10">
             <input type="password" class="form-control" id="password" name="password" placeholder="Password">
           </div>
         </div>
 
-        <div class="form-group">
-          <div class="col-sm-offset-8 col-sm-4">
-            <button type="submit" class="btn btn-primary btn-block">Log in</button>
+        <div class="mb-3 row">
+          <div class="col-sm-4 offset-sm-8">
+            <button type="submit" class="btn btn-primary btn-block w-100">Log in</button>
           </div>
         </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,51 +9,70 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "bootstrap": "3.4.1",
-        "bootstrap-datepicker": "1.7.1",
-        "bootstrap-tokenfield": "0.12.0",
-        "bootswatch": "^3.4.0",
+        "@yaireo/tagify": "^4.32.0",
+        "bootstrap": "^5.3.3",
+        "bootswatch": "^5.3.3",
+        "flatpickr": "^4.6.13",
         "font-awesome": "4.7.0",
-        "jquery": "3.5.1",
-        "typeahead.js": "0.11.1"
+        "jquery": "3.5.1"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@yaireo/tagify": {
+      "version": "4.37.1",
+      "resolved": "https://registry.npmjs.org/@yaireo/tagify/-/tagify-4.37.1.tgz",
+      "integrity": "sha512-/+0ZZ55rd4sG5Nlop2QF9D2oo3kbRgn/KlsW6oN1MwKVS7DDB2mIrGnizk740M0qzXvQfE7JhbCeWDuC8+6kmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22",
+        "pnpm": ">=10"
+      },
+      "peerDependencies": {
+        "prop-types": ">15.5.7",
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/bootstrap": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
-      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==",
-      "engines": {
-        "node": ">=6"
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
+      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@popperjs/core": "^2.11.8"
       }
-    },
-    "node_modules/bootstrap-datepicker": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/bootstrap-datepicker/-/bootstrap-datepicker-1.7.1.tgz",
-      "integrity": "sha1-Tuf680iI2+x4NPv52+fEJ34B3a8=",
-      "dependencies": {
-        "jquery": ">=1.7.1 <4.0.0"
-      }
-    },
-    "node_modules/bootstrap-tokenfield": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/bootstrap-tokenfield/-/bootstrap-tokenfield-0.12.0.tgz",
-      "integrity": "sha1-XXY8PRlt5xB4rE1J3C6hacuHDN8=",
-      "dependencies": {
-        "jquery": "^2.1.0"
-      }
-    },
-    "node_modules/bootstrap-tokenfield/node_modules/jquery": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
-      "integrity": "sha1-LInWiJterFIqfuoywUUhVZxsvwI="
     },
     "node_modules/bootswatch": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/bootswatch/-/bootswatch-3.4.1.tgz",
-      "integrity": "sha512-0hL4A8OUiqABgPipGrojf/hyhr5RS257xCNARlbK34HaMfhV5fXvwEooN4/ri9+jgX47J4Wg24ZPmfZ2xD2cKw==",
-      "engines": {
-        "node": ">= 0.10.0"
-      }
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/bootswatch/-/bootswatch-5.3.8.tgz",
+      "integrity": "sha512-88mnH9tv+x6DV+scBxYFOpM4YSDVhyfEgbhqaEfvkHNctKI9qRcACxIP9nmBZ5mSeLXtsgax1VsRkUs1eWjlAQ==",
+      "license": "MIT"
+    },
+    "node_modules/flatpickr": {
+      "version": "4.6.13",
+      "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.13.tgz",
+      "integrity": "sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw==",
+      "license": "MIT"
     },
     "node_modules/font-awesome": {
       "version": "4.7.0",
@@ -68,48 +87,114 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
       "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
     },
-    "node_modules/typeahead.js": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/typeahead.js/-/typeahead.js-0.11.1.tgz",
-      "integrity": "sha1-TmTmcbIjEKhgb0rsgFkkuoSwFbg=",
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "jquery": ">=1.7"
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT",
+      "peer": true
     }
   },
   "dependencies": {
+    "@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true
+    },
+    "@yaireo/tagify": {
+      "version": "4.37.1",
+      "resolved": "https://registry.npmjs.org/@yaireo/tagify/-/tagify-4.37.1.tgz",
+      "integrity": "sha512-/+0ZZ55rd4sG5Nlop2QF9D2oo3kbRgn/KlsW6oN1MwKVS7DDB2mIrGnizk740M0qzXvQfE7JhbCeWDuC8+6kmA==",
+      "requires": {}
+    },
     "bootstrap": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
-      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA=="
-    },
-    "bootstrap-datepicker": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/bootstrap-datepicker/-/bootstrap-datepicker-1.7.1.tgz",
-      "integrity": "sha1-Tuf680iI2+x4NPv52+fEJ34B3a8=",
-      "requires": {
-        "jquery": ">=1.7.1 <4.0.0"
-      }
-    },
-    "bootstrap-tokenfield": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/bootstrap-tokenfield/-/bootstrap-tokenfield-0.12.0.tgz",
-      "integrity": "sha1-XXY8PRlt5xB4rE1J3C6hacuHDN8=",
-      "requires": {
-        "jquery": "^2.1.0"
-      },
-      "dependencies": {
-        "jquery": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
-          "integrity": "sha1-LInWiJterFIqfuoywUUhVZxsvwI="
-        }
-      }
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
+      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
+      "requires": {}
     },
     "bootswatch": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/bootswatch/-/bootswatch-3.4.1.tgz",
-      "integrity": "sha512-0hL4A8OUiqABgPipGrojf/hyhr5RS257xCNARlbK34HaMfhV5fXvwEooN4/ri9+jgX47J4Wg24ZPmfZ2xD2cKw=="
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/bootswatch/-/bootswatch-5.3.8.tgz",
+      "integrity": "sha512-88mnH9tv+x6DV+scBxYFOpM4YSDVhyfEgbhqaEfvkHNctKI9qRcACxIP9nmBZ5mSeLXtsgax1VsRkUs1eWjlAQ=="
+    },
+    "flatpickr": {
+      "version": "4.6.13",
+      "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.13.tgz",
+      "integrity": "sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw=="
     },
     "font-awesome": {
       "version": "4.7.0",
@@ -121,13 +206,64 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
       "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
     },
-    "typeahead.js": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/typeahead.js/-/typeahead.js-0.11.1.tgz",
-      "integrity": "sha1-TmTmcbIjEKhgb0rsgFkkuoSwFbg=",
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "peer": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
       "requires": {
-        "jquery": ">=1.7"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "peer": true
+    },
+    "prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "peer": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "peer": true
+    },
+    "react-dom": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "peer": true,
+      "requires": {
+        "scheduler": "^0.27.0"
+      }
+    },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "peer": true
+    },
+    "scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "peer": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,13 +3,12 @@
   "version": "0.0.1",
   "description": "Bookmarks manager.",
   "dependencies": {
-    "bootstrap": "3.4.1",
-    "bootstrap-datepicker": "1.7.1",
-    "bootstrap-tokenfield": "0.12.0",
-    "bootswatch": "^3.4.0",
+    "@yaireo/tagify": "^4.32.0",
+    "bootstrap": "^5.3.3",
+    "bootswatch": "^5.3.3",
+    "flatpickr": "^4.6.13",
     "font-awesome": "4.7.0",
-    "jquery": "3.5.1",
-    "typeahead.js": "0.11.1"
+    "jquery": "3.5.1"
   },
   "author": "Tom Henderson",
   "license": "MIT"


### PR DESCRIPTION
- Replace bootstrap, bootswatch with Bootstrap 5 / Bootswatch 5 versions
- Replace bootstrap-tokenfield + typeahead.js with @yaireo/tagify for
  tag input (with originalInputValueFormat for django-taggit compatibility)
- Replace bootstrap-datepicker with flatpickr for the date range filter
- Use bootstrap.bundle.min.js (includes Popper) instead of separate files
- Update all templates: data-toggle/dismiss/target → data-bs-* attributes,
  col-xs-* → col-*, label label-* → badge bg-*, btn-default → btn-secondary,
  glyphicon → fa, pager → pagination, table-condensed → table-sm,
  form-horizontal → plain grid rows, control-label → col-form-label,
  input-group-addon → input-group-text, alert-dismissable → alert-dismissible,
  close button → btn-close, navbar structure updated for BS5 conventions
- Update bookmarks.css: remove tokenfield/typeahead styles, add tagify dark
  mode overrides, update label-primary selector to badge.bg-primary
- Dual-stylesheet light/dark mode approach preserved unchanged

https://claude.ai/code/session_017EmdPcix4QMcV5X9rUDnec